### PR TITLE
Fix wrong default button in subscriptions page

### DIFF
--- a/Source/Pages/Subscriptions/SubscriptionItemView.axaml
+++ b/Source/Pages/Subscriptions/SubscriptionItemView.axaml
@@ -34,8 +34,7 @@
                         MinWidth="100"
                         Margin="10,0,0,0"
                         Classes="image_button"
-                        Command="{Binding Unsubscribe}"
-                        IsDefault="True">
+                        Command="{Binding Unsubscribe}">
                     <StackPanel>
                         <PathIcon Data="{StaticResource delete_regular}" />
                         <TextBlock Text="Unsubscribe" />


### PR DESCRIPTION
This pull request fixes the issue that two buttons on the subscriptions page were marked as "default" buttons leading to strange race conditions when accepting a subscription with the enter key.