### PR TITLE
Hide port if not relevant for the specified transport protocol

### DIFF
--- a/Source/Pages/Connection/ConnectionOptionsView.axaml
+++ b/Source/Pages/Connection/ConnectionOptionsView.axaml
@@ -19,17 +19,19 @@
                     <!-- The host -->
                     <Label Grid.Column="0"
                            Classes="caption"
-                           Content="Host" />
+                           Content="{Binding ServerOptions.SelectedTransport.HostDisplayValue}" />
                     <TextBox Grid.Column="1"
                              Text="{Binding ServerOptions.Host}"
                              Classes="value" />
 
                     <Label Grid.Column="3"
                            Classes="caption"
+                           IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
                            Content="Port" />
                     <NumericUpDown Classes="value"
                                    Minimum="0"
                                    Maximum="65535"
+                                   IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
                                    Value="{Binding ServerOptions.Port}"
                                    Grid.Column="4" />
 
@@ -148,7 +150,7 @@
                       Margin="0,10,0,0">
                 <controls:AutoGrid Margin="-6"
                                    ColumnDefinitions="Auto,*,10,Auto,*">
-                    
+
                     <!-- Credentials -->
                     <Label Grid.Column="0"
                            controls:AutoGrid.IsNextRow="True"

--- a/Source/Pages/Connection/ConnectionOptionsView.axaml
+++ b/Source/Pages/Connection/ConnectionOptionsView.axaml
@@ -16,28 +16,9 @@
                 <controls:AutoGrid Margin="-6"
                                    ColumnDefinitions="Auto,*,10,Auto,*"
                                    HorizontalAlignment="Stretch">
-                    <!-- The host -->
-                    <Label Grid.Column="0"
-                           Classes="caption"
-                           Content="{Binding ServerOptions.SelectedTransport.HostDisplayValue}" />
-                    <TextBox Grid.Column="1"
-                             Text="{Binding ServerOptions.Host}"
-                             Classes="value" />
-
-                    <Label Grid.Column="3"
-                           Classes="caption"
-                           IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
-                           Content="Port" />
-                    <NumericUpDown Classes="value"
-                                   Minimum="0"
-                                   Maximum="65535"
-                                   IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
-                                   Value="{Binding ServerOptions.Port}"
-                                   Grid.Column="4" />
 
                     <!-- The transport -->
                     <Label Grid.Column="0"
-                           controls:AutoGrid.IsNextRow="True"
                            Classes="caption"
                            Content="Transport protocol" />
                     <StackPanel Grid.Column="1"
@@ -78,6 +59,26 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+
+                    <!-- The host -->
+                    <Label Grid.Column="0"
+                           controls:AutoGrid.IsNextRow="True"
+                           Classes="caption"
+                           Content="{Binding ServerOptions.SelectedTransport.HostDisplayValue}" />
+                    <TextBox Grid.Column="1"
+                             Text="{Binding ServerOptions.Host}"
+                             Classes="value" />
+
+                    <Label Grid.Column="3"
+                           Classes="caption"
+                           IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
+                           Content="Port" />
+                    <NumericUpDown Classes="value"
+                                   Minimum="0"
+                                   Maximum="65535"
+                                   IsVisible="{Binding ServerOptions.SelectedTransport.IsPortAvailable}"
+                                   Value="{Binding ServerOptions.Port}"
+                                   Grid.Column="4" />
 
                     <!-- The timeouts -->
                     <Label Grid.Column="0"

--- a/Source/Pages/Connection/ServerOptionsViewModel.cs
+++ b/Source/Pages/Connection/ServerOptionsViewModel.cs
@@ -16,7 +16,7 @@ public sealed class ServerOptionsViewModel : BaseViewModel
     EnumViewModel<MqttProtocolVersion> _selectedProtocolVersion;
 
     EnumViewModel<SslProtocols> _selectedTlsVersion;
-    EnumViewModel<Transport> _selectedTransport;
+    TransportViewModel _selectedTransport;
 
     public ServerOptionsViewModel()
     {
@@ -24,8 +24,17 @@ public sealed class ServerOptionsViewModel : BaseViewModel
         Port = 1883;
         CommunicationTimeout = 10;
 
-        Transports.Add(new EnumViewModel<Transport>("TCP", Transport.TCP));
-        Transports.Add(new EnumViewModel<Transport>("WebSocket", Transport.WebSocket));
+        Transports.Add(new TransportViewModel("TCP", Transport.TCP)
+        {
+            IsPortAvailable = true,
+            HostDisplayValue = "Host"
+        });
+
+        Transports.Add(new TransportViewModel("WebSocket", Transport.WebSocket)
+        {
+            HostDisplayValue = "URI"
+        });
+
         _selectedTransport = Transports.First();
 
         TlsVersions.Add(new EnumViewModel<SslProtocols>("no TLS", SslProtocols.None));
@@ -81,7 +90,7 @@ public sealed class ServerOptionsViewModel : BaseViewModel
         set => this.RaiseAndSetIfChanged(ref _selectedTlsVersion, value);
     }
 
-    public EnumViewModel<Transport> SelectedTransport
+    public TransportViewModel SelectedTransport
     {
         get => _selectedTransport;
         set => this.RaiseAndSetIfChanged(ref _selectedTransport, value);
@@ -89,5 +98,5 @@ public sealed class ServerOptionsViewModel : BaseViewModel
 
     public ObservableCollection<EnumViewModel<SslProtocols>> TlsVersions { get; } = new();
 
-    public ObservableCollection<EnumViewModel<Transport>> Transports { get; } = new();
+    public ObservableCollection<TransportViewModel> Transports { get; } = new();
 }

--- a/Source/Pages/Connection/TransportViewModel.cs
+++ b/Source/Pages/Connection/TransportViewModel.cs
@@ -1,0 +1,14 @@
+﻿using MQTTnetApp.Common;
+
+namespace MQTTnetApp.Pages.Connection;
+
+public sealed class TransportViewModel : EnumViewModel<Transport>
+{
+    public TransportViewModel(object displayValue, Transport value) : base(displayValue, value)
+    {
+    }
+
+    public object HostDisplayValue { get; set; }
+
+    public bool IsPortAvailable { get; set; }
+}


### PR DESCRIPTION
This pull request ensures that the port and the port label are hidden when WebSockets are selected as the transport.