### PR TITLE
Enhance TLS configuration and error handling in MqttClientService

### DIFF
--- a/Source/Services/Mqtt/MqttClientService.cs
+++ b/Source/Services/Mqtt/MqttClientService.cs
@@ -101,6 +101,7 @@ public sealed class MqttClientService
         {
             clientOptionsBuilder.WithTlsOptions(o =>
             {
+                o.UseTls();
                 o.WithSslProtocols(item.ServerOptions.SelectedTlsVersion.Value);
                 o.WithIgnoreCertificateChainErrors(item.ServerOptions.IgnoreCertificateErrors);
                 o.WithIgnoreCertificateRevocationErrors(item.ServerOptions.IgnoreCertificateErrors);
@@ -108,7 +109,9 @@ public sealed class MqttClientService
                 if (item.ServerOptions.IgnoreCertificateErrors)
                 {
                     o.WithCertificateValidationHandler(context => true);
-                    o.WithAllowUntrustedCertificates();
+                    o.WithAllowUntrustedCertificates(true); 
+                    o.WithIgnoreCertificateChainErrors(true);
+                    o.WithIgnoreCertificateRevocationErrors(true); 
                 }
 
                 if (!string.IsNullOrEmpty(item.SessionOptions.CertificatePath))


### PR DESCRIPTION
Fix https://github.com/chkr1011/mqttMultimeter/issues/109
This pull request updates the MQTT client connection logic to improve certificate error handling and provide better exception context. The main changes are focused on how untrusted certificates are managed and how timeout exceptions are reported.

**Certificate error handling improvements:**

* When `IgnoreCertificateErrors` is enabled, the client now explicitly sets a certificate validation handler that always returns true and allows untrusted certificates, making the intent clearer and more robust.

**Exception handling enhancements:**

* When a connection attempt times out, the original exception is now passed to the `MqttCommunicationTimedOutException`, preserving the exception context for easier debugging.